### PR TITLE
Typo Edit/Command Edit

### DIFF
--- a/src/main/java/dansplugins/currencies/commands/DepositCommand.java
+++ b/src/main/java/dansplugins/currencies/commands/DepositCommand.java
@@ -25,7 +25,7 @@ public class DepositCommand extends AbstractPluginCommand {
 
     @Override
     public boolean execute(CommandSender sender) {
-        sender.sendMessage(ChatColor.RED + "Usage: /c deposit 'currency' 'amount'");
+        sender.sendMessage(ChatColor.RED + "Usage: /c deposit \"currency\" \"amount\"");
         return false;
     }
 
@@ -38,7 +38,7 @@ public class DepositCommand extends AbstractPluginCommand {
         Player player = (Player) sender;
 
         if (args.length < 2) {
-            player.sendMessage(ChatColor.RED + "Usage: /c deposit 'currency' 'amount'");
+            player.sendMessage(ChatColor.RED + "Usage: /c deposit \"currency\" \"amount\"");
             return false;
         }
 

--- a/src/main/java/dansplugins/currencies/commands/InfoCommand.java
+++ b/src/main/java/dansplugins/currencies/commands/InfoCommand.java
@@ -27,7 +27,7 @@ public class InfoCommand extends AbstractPluginCommand {
     @Override
     public boolean execute(CommandSender sender) {
         if (!(sender instanceof Player)) {
-            sender.sendMessage("This command can't be used int the console.");
+            sender.sendMessage("This command can't be used in the console.");
             return false;
         }
 

--- a/src/main/java/dansplugins/currencies/commands/WithdrawCommand.java
+++ b/src/main/java/dansplugins/currencies/commands/WithdrawCommand.java
@@ -25,7 +25,7 @@ public class WithdrawCommand extends AbstractPluginCommand {
 
     @Override
     public boolean execute(CommandSender sender) {
-        sender.sendMessage(ChatColor.RED + "Usage: /c withdraw 'currency' 'amount'");
+        sender.sendMessage(ChatColor.RED + "Usage: /c withdraw \"currency\" \"amount\"");
         return false;
     }
 
@@ -38,7 +38,7 @@ public class WithdrawCommand extends AbstractPluginCommand {
         Player player = (Player) sender;
 
         if (args.length < 2) {
-            player.sendMessage(ChatColor.RED + "Usage: /c withdraw 'currency' 'amount'");
+            player.sendMessage(ChatColor.RED + "Usage: /c withdraw \"currency\" \"amount\"");
             return false;
         }
 


### PR DESCRIPTION
Edited a typo in InfoCommand

Changed the Deposit and Withdraw Commands so that they display the correct quotation commands instead of using single quites.