### PR TITLE
Improvement - Make Item Name Match Currency Name

### DIFF
--- a/src/main/kotlin/com/dansplugins/currencies/command/currency/create/CurrencyCreateCommand.kt
+++ b/src/main/kotlin/com/dansplugins/currencies/command/currency/create/CurrencyCreateCommand.kt
@@ -43,6 +43,7 @@ class CurrencyCreateCommand(private val plugin: Currencies) : CommandExecutor, T
         item.amount = 1
         item.itemMeta = (item.itemMeta ?: plugin.server.itemFactory.getItemMeta(item.type))?.apply {
             persistentDataContainer.set(currencyIdKey, STRING, currencyId.value)
+            setDisplayName(args.joinToString(" "))
         }
         val medievalFactions = plugin.medievalFactions
         plugin.server.scheduler.runTaskAsynchronously(plugin, Runnable {


### PR DESCRIPTION
The changes in this PR make the name of an item for a currency match the currency's name.

We will need to handle the case where currencies are renamed, but this can be resolved in a future PR. I've created #182 for this.

closes #180 